### PR TITLE
Normalize dashboard statistic pie data

### DIFF
--- a/src/pages/Dashboard/Index.vue
+++ b/src/pages/Dashboard/Index.vue
@@ -1,13 +1,26 @@
 <script setup>
-import { onMounted, ref } from 'vue'
+import { nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import api from '../../lib/axios'
 
 // ====== CHART.JS (faqat front mock) ======
 import {
   Chart,
   LineController, LineElement, PointElement,
-  CategoryScale, LinearScale, Tooltip, Filler
+  CategoryScale, LinearScale, Tooltip, Filler,
+  PieController, ArcElement, Legend
 } from 'chart.js'
-Chart.register(LineController, LineElement, PointElement, CategoryScale, LinearScale, Tooltip, Filler)
+Chart.register(
+  LineController,
+  LineElement,
+  PointElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Filler,
+  PieController,
+  ArcElement,
+  Legend
+)
 
 // ---------- STATIK TOP STATS ----------
 const topStats = ref([
@@ -20,6 +33,24 @@ const topStats = ref([
 // ---------- STATIK CHART MA’LUMOTI ----------
 const chartCanvas = ref(null)
 let chartInstance = null
+
+const regionChartCanvas = ref(null)
+const ageChartCanvas = ref(null)
+const genderChartCanvas = ref(null)
+
+let regionChartInstance = null
+let ageChartInstance = null
+let genderChartInstance = null
+
+const regionChartData = ref({ labels: [], values: [] })
+const ageChartData = ref({ labels: [], values: [] })
+const genderChartData = ref({ labels: [], values: [] })
+
+const pieLoading = ref(false)
+const pieError = ref('')
+
+const numberFormatter = new Intl.NumberFormat('ru-RU')
+const formatNumber = (value) => numberFormatter.format(value ?? 0)
 
 const chartLabels = [
   '08:00','09:00','10:00','11:00','12:00','13:00',
@@ -59,6 +90,215 @@ function drawChart() {
   })
 }
 
+const piePalette = ['#0ea5e9', '#22d3ee', '#6366f1', '#a855f7', '#f472b6', '#f97316', '#facc15', '#34d399', '#14b8a6', '#fb7185']
+
+function getPieColors(count) {
+  if (count <= piePalette.length) {
+    return piePalette.slice(0, count)
+  }
+  const colors = []
+  for (let i = 0; i < count; i += 1) {
+    colors.push(piePalette[i % piePalette.length])
+  }
+  return colors
+}
+
+function drawPieChart(canvasRef, dataset, currentInstance) {
+  if (currentInstance) {
+    currentInstance.destroy()
+  }
+  const canvas = canvasRef.value
+  if (!canvas || !dataset.values.length) {
+    return null
+  }
+  const ctx = canvas.getContext('2d')
+  if (!ctx) {
+    return null
+  }
+  const colors = getPieColors(dataset.values.length)
+  return new Chart(ctx, {
+    type: 'pie',
+    data: {
+      labels: dataset.labels,
+      datasets: [
+        {
+          data: dataset.values,
+          backgroundColor: colors,
+          borderColor: '#ffffff',
+          borderWidth: 2,
+          hoverOffset: 8
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: { duration: 600 },
+      layout: { padding: 10 },
+      plugins: {
+        legend: {
+          position: 'bottom',
+          labels: {
+            usePointStyle: true,
+            pointStyle: 'circle',
+            boxWidth: 10,
+            padding: 16
+          }
+        },
+        tooltip: {
+          callbacks: {
+            label: (context) => {
+              const datasetValues = context.chart.data.datasets[0]?.data ?? []
+              const total = datasetValues.reduce((sum, value) => sum + (Number(value) || 0), 0)
+              const currentValue = Number(context.parsed) || 0
+              const percentage = total ? ((currentValue / total) * 100).toFixed(1) : '0.0'
+              const formattedValue = formatNumber(currentValue)
+              return `${context.label}: ${formattedValue} (${percentage}%)`
+            }
+          }
+        }
+      }
+    }
+  })
+}
+
+function parseNumber(value) {
+  const numeric = Number(value)
+  return Number.isFinite(numeric) ? numeric : 0
+}
+
+function ensureArray(value) {
+  if (Array.isArray(value)) {
+    return value
+  }
+  if (value && typeof value === 'object') {
+    if (Array.isArray(value.data)) {
+      return value.data
+    }
+    return Object.values(value)
+  }
+  return []
+}
+
+function pickFirst(obj, keys) {
+  for (const key of keys) {
+    if (key.includes('.')) {
+      const [first, second] = key.split('.')
+      if (obj?.[first]?.[second] !== undefined) {
+        return obj[first][second]
+      }
+    } else if (Object.prototype.hasOwnProperty.call(obj ?? {}, key)) {
+      return obj[key]
+    }
+  }
+  return undefined
+}
+
+function resolveLabel(value) {
+  if (value == null) {
+    return 'Nomaʼlum'
+  }
+  if (typeof value === 'object') {
+    if (typeof value.name === 'string' && value.name.trim()) {
+      return value.name
+    }
+    if (typeof value.title === 'string' && value.title.trim()) {
+      return value.title
+    }
+    return 'Nomaʼlum'
+  }
+  const label = String(value).trim()
+  return label || 'Nomaʼlum'
+}
+
+async function loadStatisticPies() {
+  pieLoading.value = true
+  pieError.value = ''
+
+  const resetData = () => {
+    regionChartData.value = { labels: [], values: [] }
+    ageChartData.value = { labels: [], values: [] }
+    genderChartData.value = { labels: [], values: [] }
+  }
+
+  try {
+    const { data } = await api.get('/dashboard/statistic')
+    const payload = data?.data ?? data ?? {}
+
+    const regions = ensureArray(
+      payload.byRegion ??
+        payload.region ??
+        payload.regions ??
+        payload.regionStats ??
+        payload.region_statistics ??
+        payload.regionStatistics ??
+        payload.region_distribution
+    )
+    regionChartData.value = {
+      labels: regions.map((item) => {
+        const raw = pickFirst(item, ['region', 'region_name', 'name', 'label', 'title', 'region.title', 'region.name'])
+        return resolveLabel(raw)
+      }),
+      values: regions.map((item) => parseNumber(pickFirst(item, ['cnt', 'count', 'value', 'total', 'amount', 'sum'])))
+    }
+
+    const ages = ensureArray(
+      payload.byAge ??
+        payload.age ??
+        payload.ages ??
+        payload.ageStats ??
+        payload.age_statistics ??
+        payload.ageStatistics ??
+        payload.age_distribution
+    )
+    ageChartData.value = {
+      labels: ages.map((item) => {
+        const raw = pickFirst(item, ['age_range', 'range', 'label', 'title', 'name'])
+        return resolveLabel(raw)
+      }),
+      values: ages.map((item) => parseNumber(pickFirst(item, ['count', 'cnt', 'value', 'total', 'amount'])))
+    }
+
+    const genders = ensureArray(
+      payload.byGender ??
+        payload.gender ??
+        payload.genders ??
+        payload.genderStats ??
+        payload.gender_statistics ??
+        payload.genderStatistics ??
+        payload.gender_distribution
+    )
+    const genderLabels = []
+    const genderValues = []
+    genders.forEach((item) => {
+      let label = pickFirst(item, ['label', 'title', 'name'])
+      if (!label) {
+        const genderRaw = pickFirst(item, ['gender', 'gender_name', 'code'])
+        if (genderRaw === 1 || genderRaw === '1' || genderRaw === 'male' || genderRaw === 'erkak') {
+          label = 'Erkaklar'
+        } else if (genderRaw === 2 || genderRaw === '2' || genderRaw === 'female' || genderRaw === 'ayol') {
+          label = 'Ayollar'
+        } else if (genderRaw) {
+          label = String(genderRaw)
+        }
+      }
+      genderLabels.push(resolveLabel(label))
+      genderValues.push(parseNumber(pickFirst(item, ['cnt', 'count', 'value', 'total', 'amount'])))
+    })
+    genderChartData.value = { labels: genderLabels, values: genderValues }
+  } catch (error) {
+    console.error('Failed to load dashboard statistics', error)
+    pieError.value = 'Maʼlumotlarni yuklashda xatolik yuz berdi.'
+    resetData()
+  } finally {
+    await nextTick()
+    regionChartInstance = drawPieChart(regionChartCanvas, regionChartData.value, regionChartInstance)
+    ageChartInstance = drawPieChart(ageChartCanvas, ageChartData.value, ageChartInstance)
+    genderChartInstance = drawPieChart(genderChartCanvas, genderChartData.value, genderChartInstance)
+    pieLoading.value = false
+  }
+}
+
 // ---------- STATIK BUGUNGI TRANZAKSIYALAR (10 ta) ----------
 const trxToday = ref([
   { id: 'TRX-1001', user: 'Bobur Boburov',   system: 'Payme', amount: '1 000 000 UZS', date: '01.09.2025', time: '09:05:18', status: 'Yakunlangan' },
@@ -87,7 +327,17 @@ const usersToday = ref([
   { id: 'U-1010', name: 'Gulbahor Hamidova',  phone: '+998 94 888 77 66', date: '01.09.2025', time: '17:02:59' },
 ])
 
-onMounted(drawChart)
+onMounted(async () => {
+  drawChart()
+  await loadStatisticPies()
+})
+
+onBeforeUnmount(() => {
+  chartInstance?.destroy()
+  regionChartInstance?.destroy()
+  ageChartInstance?.destroy()
+  genderChartInstance?.destroy()
+})
 </script>
 
 <template>
@@ -121,7 +371,115 @@ onMounted(drawChart)
       <div class="h-80">
         <canvas ref="chartCanvas"></canvas>
       </div>
-    </div> 
+    </div>
+
+    <!-- Distribution pie charts -->
+    <div class="grid gap-6 xl:grid-cols-3">
+      <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm flex flex-col">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <h3 class="text-base font-semibold text-slate-800">Hududlar kesimida</h3>
+          </div>
+          <RouterLink
+            to="/admin/detail-table/region"
+            class="inline-flex items-center rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold text-white transition hover:bg-slate-700"
+          >
+            Batafsil
+          </RouterLink>
+        </div>
+        <div class="mt-6 flex-1">
+          <div v-if="pieLoading" class="flex h-64 items-center justify-center">
+            <svg class="h-6 w-6 animate-spin text-slate-400" viewBox="0 0 24 24" fill="none">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+              />
+            </svg>
+          </div>
+          <div v-else-if="pieError" class="flex h-64 items-center justify-center text-center text-sm text-rose-500">
+            {{ pieError }}
+          </div>
+          <div v-else-if="!regionChartData.values.length" class="flex h-64 items-center justify-center text-sm text-slate-400">
+            Maʼlumot mavjud emas
+          </div>
+          <div v-else class="relative mx-auto aspect-square h-64 max-w-xs">
+            <canvas ref="regionChartCanvas"></canvas>
+          </div>
+        </div>
+      </div>
+
+      <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm flex flex-col">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <h3 class="text-base font-semibold text-slate-800">Yosh kesimida</h3>
+          </div>
+          <RouterLink
+            to="/admin/detail-table/age"
+            class="inline-flex items-center rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold text-white transition hover:bg-slate-700"
+          >
+            Batafsil
+          </RouterLink>
+        </div>
+        <div class="mt-6 flex-1">
+          <div v-if="pieLoading" class="flex h-64 items-center justify-center">
+            <svg class="h-6 w-6 animate-spin text-slate-400" viewBox="0 0 24 24" fill="none">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+              />
+            </svg>
+          </div>
+          <div v-else-if="pieError" class="flex h-64 items-center justify-center text-center text-sm text-rose-500">
+            {{ pieError }}
+          </div>
+          <div v-else-if="!ageChartData.values.length" class="flex h-64 items-center justify-center text-sm text-slate-400">
+            Maʼlumot mavjud emas
+          </div>
+          <div v-else class="relative mx-auto aspect-square h-64 max-w-xs">
+            <canvas ref="ageChartCanvas"></canvas>
+          </div>
+        </div>
+      </div>
+
+      <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm flex flex-col">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <h3 class="text-base font-semibold text-slate-800">Jins kesimida</h3>
+          </div>
+          <RouterLink
+            to="/admin/detail-table/gender"
+            class="inline-flex items-center rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold text-white transition hover:bg-slate-700"
+          >
+            Batafsil
+          </RouterLink>
+        </div>
+        <div class="mt-6 flex-1">
+          <div v-if="pieLoading" class="flex h-64 items-center justify-center">
+            <svg class="h-6 w-6 animate-spin text-slate-400" viewBox="0 0 24 24" fill="none">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+              />
+            </svg>
+          </div>
+          <div v-else-if="pieError" class="flex h-64 items-center justify-center text-center text-sm text-rose-500">
+            {{ pieError }}
+          </div>
+          <div v-else-if="!genderChartData.values.length" class="flex h-64 items-center justify-center text-sm text-slate-400">
+            Maʼlumot mavjud emas
+          </div>
+          <div v-else class="relative mx-auto aspect-square h-64 max-w-xs">
+            <canvas ref="genderChartCanvas"></canvas>
+          </div>
+        </div>
+      </div>
+    </div>
 
     <!-- 2 big cards row -->
     <div class="grid gap-6 xl:grid-cols-2">


### PR DESCRIPTION
## Summary
- broaden the statistic payload parsing so pie charts load from any `/dashboard/statistic` field layout
- drop the unused "Jami" totals from the region, age, and gender cards per the refreshed design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fc4f019e0c832691b0662a3216b6d6